### PR TITLE
feat(equality fn): change to object and add metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@zdavison/strangler",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "private": false,
   "description": "A utility for swapping out implementations at runtime, and comparing them over time to avoid regressions.",
   "repository": "https://github.com/mm-zacharydavison/strangler",

--- a/src/strangler.spec.ts
+++ b/src/strangler.spec.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach } from 'vitest'
 import {
   type AsyncFunction,
   type AsyncService,
   type FeatureFlag,
   Strangler,
   type StranglerMode,
-} from "./strangler";
+} from './strangler'
 
 // Mock logger that doesn't output anything
 const mockLogger = {
@@ -14,371 +14,357 @@ const mockLogger = {
   info: () => {},
   log: () => {},
   debug: () => {},
-};
+}
 
 type TestService = AsyncService & {
-  method1: (text?: string, value?: number) => Promise<string>;
-  method2: () => Promise<string>;
-  method3: () => Promise<string>;
-};
+  method1: (text?: string, value?: number) => Promise<string>
+  method2: () => Promise<string>
+  method3: () => Promise<string>
+}
 
-describe("Strangler", () => {
-  describe("Basic Features", () => {
+describe('Strangler', () => {
+  describe('Basic Features', () => {
     // Not specifying the types allows us to also test type inference of `Strangler` arguments.
     const oldImpl = {
-      method1: async () => "old",
-      method2: async () => "old2",
-      method3: async () => "old3",
-    };
+      method1: async () => 'old',
+      method2: async () => 'old2',
+      method3: async () => 'old3',
+    }
 
     const newImpl = {
-      method1: async () => "new",
-      method2: async () => "new2",
-    };
+      method1: async () => 'new',
+      method2: async () => 'new2',
+    }
 
-    it("WILL allow runtime toggling between two implementations", async () => {
-      let flagValue: StranglerMode = "old";
-      const featureFlag = async () => flagValue;
-      const service = Strangler(featureFlag, newImpl, oldImpl);
+    it('WILL allow runtime toggling between two implementations', async () => {
+      let flagValue: StranglerMode = 'old'
+      const featureFlag = async () => flagValue
+      const service = Strangler(featureFlag, newImpl, oldImpl)
 
-      expect(await service.method1()).toBe("old");
-      flagValue = "new";
-      expect(await service.method1()).toBe("new");
-    });
+      expect(await service.method1()).toBe('old')
+      flagValue = 'new'
+      expect(await service.method1()).toBe('new')
+    })
 
-    it("WILL allow toggling by individual method", async () => {
-      const featureFlag: FeatureFlag = async () => "new";
+    it('WILL allow toggling by individual method', async () => {
+      const featureFlag: FeatureFlag = async () => 'new'
       const service = Strangler(
         featureFlag,
         {
           method1: oldImpl.method1,
           method2: newImpl.method2,
         },
-        oldImpl
-      );
+        oldImpl,
+      )
 
-      expect(await service.method1()).toBe("old");
-      expect(await service.method2()).toBe("new2");
-    });
+      expect(await service.method1()).toBe('old')
+      expect(await service.method2()).toBe('new2')
+    })
 
-    it("Methods that are not implemented in the NEW service are called in the OLD service", async () => {
-      const featureFlag: FeatureFlag = async () => "new";
-      const service = Strangler(featureFlag, newImpl, oldImpl);
+    it('Methods that are not implemented in the NEW service are called in the OLD service', async () => {
+      const featureFlag: FeatureFlag = async () => 'new'
+      const service = Strangler(featureFlag, newImpl, oldImpl)
 
-      const result = await service.method3?.();
-      expect(result).toBe("old3");
-    });
-  });
+      const result = await service.method3?.()
+      expect(result).toBe('old3')
+    })
+  })
 
-  describe("Basic Features (with classes)", () => {
+  describe('Basic Features (with classes)', () => {
     class OldImpl implements TestService {
-      [key: string]: AsyncFunction | unknown;
-      instanceVariable = "old";
+      [key: string]: AsyncFunction | unknown
+      instanceVariable = 'old'
       async method1() {
-        return this.instanceVariable;
+        return this.instanceVariable
       }
       async method2() {
-        return "old2";
+        return 'old2'
       }
       async method3() {
-        return "old3";
+        return 'old3'
       }
     }
-    const oldImpl = new OldImpl();
+    const oldImpl = new OldImpl()
 
     class NewImpl implements Partial<TestService> {
-      [key: string]: AsyncFunction | unknown;
-      instanceVariable = "new";
+      [key: string]: AsyncFunction | unknown
+      instanceVariable = 'new'
       async method1() {
-        return this.instanceVariable;
+        return this.instanceVariable
       }
       async method2() {
-        return "new2";
+        return 'new2'
       }
     }
-    const newImpl = new NewImpl();
+    const newImpl = new NewImpl()
 
-    it("WILL allow runtime toggling between two implementations", async () => {
-      let flagValue: StranglerMode = "old";
-      const featureFlag = async () => flagValue;
-      const service = Strangler(featureFlag, newImpl, oldImpl);
+    it('WILL allow runtime toggling between two implementations', async () => {
+      let flagValue: StranglerMode = 'old'
+      const featureFlag = async () => flagValue
+      const service = Strangler(featureFlag, newImpl, oldImpl)
 
-      expect(await service.method1()).toBe("old");
-      flagValue = "new";
-      expect(await service.method1()).toBe("new");
-    });
+      expect(await service.method1()).toBe('old')
+      flagValue = 'new'
+      expect(await service.method1()).toBe('new')
+    })
 
-    it("WILL allow toggling by individual method", async () => {
-      const featureFlag: FeatureFlag = async () => "new";
+    it('WILL allow toggling by individual method', async () => {
+      const featureFlag: FeatureFlag = async () => 'new'
       class NewImpl2 implements TestService {
-        instanceVariable = "old";
+        instanceVariable = 'old'
         async method1() {
-          return this.instanceVariable;
+          return this.instanceVariable
         }
         async method2() {
-          return "new2";
+          return 'new2'
         }
         async method3() {
-          return "new3";
+          return 'new3'
         }
       }
-      const newImpl2 = new NewImpl2();
-      const service = Strangler(featureFlag, newImpl2, oldImpl);
+      const newImpl2 = new NewImpl2()
+      const service = Strangler(featureFlag, newImpl2, oldImpl)
 
-      expect(await service.method1()).toBe("old");
-      expect(await service.method2()).toBe("new2");
-    });
+      expect(await service.method1()).toBe('old')
+      expect(await service.method2()).toBe('new2')
+    })
 
-    it("Methods that are not implemented in the NEW service are called in the OLD service", async () => {
-      const featureFlag: FeatureFlag = async () => "new";
-      const service = Strangler<TestService, keyof TestService>(
-        featureFlag,
-        newImpl,
-        oldImpl
-      );
+    it('Methods that are not implemented in the NEW service are called in the OLD service', async () => {
+      const featureFlag: FeatureFlag = async () => 'new'
+      const service = Strangler<TestService, keyof TestService>(featureFlag, newImpl, oldImpl)
 
-      const result = await service.method3();
-      expect(result).toBe("old3");
-    });
-  });
-  describe("Comparison Features", () => {
-    let oldImpl: Omit<TestService, "method3">;
-    let newImpl: Omit<TestService, "method3">;
-    let featureFlag: FeatureFlag;
+      const result = await service.method3()
+      expect(result).toBe('old3')
+    })
+  })
+  describe('Comparison Features', () => {
+    let oldImpl: Omit<TestService, 'method3'>
+    let newImpl: Omit<TestService, 'method3'>
+    let featureFlag: FeatureFlag
 
     beforeEach(() => {
       oldImpl = {
-        method1: async () => "old",
-        method2: async () => "old2",
-      };
+        method1: async () => 'old',
+        method2: async () => 'old2',
+      }
       newImpl = {
-        method1: async () => "new",
-        method2: async () => "new2",
-      };
-      featureFlag = async () => "old";
-    });
+        method1: async () => 'new',
+        method2: async () => 'new2',
+      }
+      featureFlag = async () => 'old'
+    })
 
-    it("WILL execute both implementations, and compare their return values", async () => {
-      const comparisons: any[] = [];
-      featureFlag = async () => "new-compare";
+    it('WILL execute both implementations, and compare their return values', async () => {
+      const comparisons: any[] = []
+      featureFlag = async () => 'new-compare'
 
       // Create a promise that will resolve when onComparison is called
-      let resolveComparisonPromise: () => void;
+      let resolveComparisonPromise: () => void
       const comparisonPromise = new Promise<void>((resolve) => {
-        resolveComparisonPromise = resolve;
-      });
+        resolveComparisonPromise = resolve
+      })
 
       const service = Strangler(featureFlag, newImpl, oldImpl, (comparison) => {
-        comparisons.push(comparison);
-        resolveComparisonPromise();
-      });
+        comparisons.push(comparison)
+        resolveComparisonPromise()
+      })
 
-      const result = await service.method1();
+      const result = await service.method1()
 
       // Wait for the comparison to be completed
-      await comparisonPromise;
+      await comparisonPromise
 
-      expect(comparisons).toHaveLength(1);
+      expect(comparisons).toHaveLength(1)
       expect(comparisons[0]).toMatchObject({
-        oldResult: "old",
-        newResult: "new",
-        methodName: "method1",
-      });
-      expect(result).toBe("new");
-    });
+        oldResult: 'old',
+        newResult: 'new',
+        methodName: 'method1',
+      })
+      expect(result).toBe('new')
+    })
 
-    it("WILL execute both implementations, and compare their performance", async () => {
+    it('WILL execute both implementations, and compare their performance', async () => {
       const slowNewImpl = {
         method1: async () => {
-          await new Promise((resolve) => setTimeout(resolve, 50));
-          return "new";
+          await new Promise((resolve) => setTimeout(resolve, 50))
+          return 'new'
         },
-        method2: async () => "method2",
-        method3: async () => "method3",
-      };
+        method2: async () => 'method2',
+        method3: async () => 'method3',
+      }
 
-      const comparisons: any[] = [];
-      featureFlag = async () => "old-compare";
+      const comparisons: any[] = []
+      featureFlag = async () => 'old-compare'
 
       // Create a promise that will resolve when onComparison is called
-      let resolveComparisonPromise: () => void;
+      let resolveComparisonPromise: () => void
       const comparisonPromise = new Promise<void>((resolve) => {
-        resolveComparisonPromise = resolve;
-      });
+        resolveComparisonPromise = resolve
+      })
 
       const service = Strangler(
         featureFlag,
         slowNewImpl,
         oldImpl,
         (comparison) => {
-          comparisons.push(comparison);
-          resolveComparisonPromise();
+          comparisons.push(comparison)
+          resolveComparisonPromise()
         },
         {
           acceptableDurationDifference: 0, // Always log.
-        }
-      );
+        },
+      )
 
-      const result = await service.method1();
+      const result = await service.method1()
 
       // Wait for the comparison to be completed
-      await comparisonPromise;
+      await comparisonPromise
 
-      expect(comparisons).toHaveLength(1);
-      expect(comparisons[0].newDuration).toBeGreaterThan(45);
-      expect(comparisons[0].oldDuration).toBeLessThan(45);
-      expect(result).toBe("old");
-    });
+      expect(comparisons).toHaveLength(1)
+      expect(comparisons[0].newDuration).toBeGreaterThan(45)
+      expect(comparisons[0].oldDuration).toBeLessThan(45)
+      expect(result).toBe('old')
+    })
 
-    it("IF the values are not different, nothing is logged", async () => {
+    it('IF the values are not different, nothing is logged', async () => {
       const sameImpl = {
-        method1: async () => "same",
-        method2: async () => "method2",
-        method3: async () => "method3",
-      };
+        method1: async () => 'same',
+        method2: async () => 'method2',
+        method3: async () => 'method3',
+      }
 
-      const comparisons: any[] = [];
-      featureFlag = async () => "new-compare";
-      const service = Strangler(
-        featureFlag,
-        sameImpl,
-        sameImpl,
-        (comparison) => {
-          comparisons.push(comparison);
-        }
-      );
+      const comparisons: any[] = []
+      featureFlag = async () => 'new-compare'
+      const service = Strangler(featureFlag, sameImpl, sameImpl, (comparison) => {
+        comparisons.push(comparison)
+      })
 
-      await service.method1();
-      expect(comparisons).toHaveLength(0);
-    });
+      await service.method1()
+      expect(comparisons).toHaveLength(0)
+    })
 
-    it("IF the durations do not differ by more than the predefined threshold, nothing is logged", async () => {
+    it('IF the durations do not differ by more than the predefined threshold, nothing is logged', async () => {
       const fastImpl = {
-        method1: async () => "fast",
-        method2: async () => "method2",
-        method3: async () => "method3",
-      };
+        method1: async () => 'fast',
+        method2: async () => 'method2',
+        method3: async () => 'method3',
+      }
 
-      const comparisons: any[] = [];
-      featureFlag = async () => "new-compare";
+      const comparisons: any[] = []
+      featureFlag = async () => 'new-compare'
       const service = Strangler(
         featureFlag,
         fastImpl,
         { ...fastImpl },
         (comparison) => {
-          comparisons.push(comparison);
+          comparisons.push(comparison)
         },
-        { acceptableDurationDifference: 1000 }
-      );
+        { acceptableDurationDifference: 1000 },
+      )
 
-      await service.method1();
-      expect(comparisons).toHaveLength(0);
-    });
+      await service.method1()
+      expect(comparisons).toHaveLength(0)
+    })
 
-    it("WILL NOT compare implementations when not in compare mode", async () => {
-      for (const mode of ["old", "new"]) {
-        const comparisons: unknown[] = [];
-        const featureFlag = async () => mode as StranglerMode;
-        const service = Strangler(
-          featureFlag,
-          newImpl,
-          oldImpl,
-          (comparison) => {
-            comparisons.push(comparison);
-          }
-        );
+    it('WILL NOT compare implementations when not in compare mode', async () => {
+      for (const mode of ['old', 'new']) {
+        const comparisons: unknown[] = []
+        const featureFlag = async () => mode as StranglerMode
+        const service = Strangler(featureFlag, newImpl, oldImpl, (comparison) => {
+          comparisons.push(comparison)
+        })
 
-        expect(await service.method1()).toBe(mode);
+        expect(await service.method1()).toBe(mode)
       }
-    });
+    })
 
-    it("WILL include all arguments in the OnComparison result.", async () => {
-      const comparisons: any[] = [];
-      featureFlag = async () => "new-compare";
+    it('WILL include all arguments in the OnComparison result.', async () => {
+      const comparisons: any[] = []
+      featureFlag = async () => 'new-compare'
 
       // Create a promise that will resolve when onComparison is called
-      let resolveComparisonPromise: () => void;
+      let resolveComparisonPromise: () => void
       const comparisonPromise = new Promise<void>((resolve) => {
-        resolveComparisonPromise = resolve;
-      });
+        resolveComparisonPromise = resolve
+      })
 
       const service = Strangler(featureFlag, newImpl, oldImpl, (comparison) => {
-        comparisons.push(comparison);
-        resolveComparisonPromise();
-      });
+        comparisons.push(comparison)
+        resolveComparisonPromise()
+      })
 
-      await service.method1("test", 123);
+      await service.method1('test', 123)
 
       // Wait for the comparison to be completed
-      await comparisonPromise;
+      await comparisonPromise
 
-      expect(comparisons[0].parameters).toEqual(["test", 123]);
-    });
+      expect(comparisons[0].parameters).toEqual(['test', 123])
+    })
 
-    it("WILL NOT wait for the slowest of the two operations to complete before returning the one in use.", async () => {
+    it('WILL NOT wait for the slowest of the two operations to complete before returning the one in use.', async () => {
       // Create a very slow implementation
       const verySlowImpl = {
         method1: async () => {
-          await new Promise((resolve) => setTimeout(resolve, 500));
-          return "very-slow";
+          await new Promise((resolve) => setTimeout(resolve, 500))
+          return 'very-slow'
         },
-        method2: async () => "method2",
-        method3: async () => "method3",
-      };
+        method2: async () => 'method2',
+        method3: async () => 'method3',
+      }
 
       // Create a fast implementation
       const fastImpl = {
         method1: async () => {
-          return "fast";
+          return 'fast'
         },
-        method2: async () => "method2",
-        method3: async () => "method3",
-      };
+        method2: async () => 'method2',
+        method3: async () => 'method3',
+      }
 
       // Test with old-compare mode (using the fast implementation)
-      featureFlag = async () => "old-compare";
+      featureFlag = async () => 'old-compare'
       const service = Strangler(
         featureFlag,
         verySlowImpl, // new implementation (slow)
         fastImpl, // old implementation (fast)
-        () => {} // empty comparison function
-      );
+        () => {}, // empty comparison function
+      )
 
       // Measure how long it takes to get the result
-      const startTime = performance.now();
-      const result = await service.method1();
-      const duration = performance.now() - startTime;
+      const startTime = performance.now()
+      const result = await service.method1()
+      const duration = performance.now() - startTime
 
       // Verify that we got the result from the fast implementation
-      expect(result).toBe("fast");
+      expect(result).toBe('fast')
 
       // Verify that the duration is much less than 500ms (the time of the slow implementation)
       // We allow some buffer time for test execution overhead
-      expect(duration).toBeLessThan(300);
-    });
+      expect(duration).toBeLessThan(300)
+    })
 
-    it("WILL wait for the slowest of the two operations to complete before returning the one in use if requested in the options", async () => {
+    it('WILL wait for the slowest of the two operations to complete before returning the one in use if requested in the options', async () => {
       // Create a very slow implementation
       const verySlowImpl = {
         method1: async () => {
-          await new Promise((resolve) => setTimeout(resolve, 500));
-          return "very-slow";
+          await new Promise((resolve) => setTimeout(resolve, 500))
+          return 'very-slow'
         },
-        method2: async () => "method2",
-        method3: async () => "method3",
-      };
+        method2: async () => 'method2',
+        method3: async () => 'method3',
+      }
 
       // Create a fast implementation
       const fastImpl = {
         method1: async () => {
-          return "fast";
+          return 'fast'
         },
-        method2: async () => "method2",
-        method3: async () => "method3",
-      };
+        method2: async () => 'method2',
+        method3: async () => 'method3',
+      }
 
       // Test with old-compare mode (using the fast implementation)
-      featureFlag = async () => "old-compare";
+      featureFlag = async () => 'old-compare'
       const service = Strangler(
         featureFlag,
         verySlowImpl, // new implementation (slow)
@@ -386,325 +372,315 @@ describe("Strangler", () => {
         () => {}, // empty comparison function
         {
           waitForComparison: true,
-        }
-      );
+        },
+      )
 
       // Measure how long it takes to get the result
-      const startTime = performance.now();
-      const result = await service.method1();
-      const duration = performance.now() - startTime;
+      const startTime = performance.now()
+      const result = await service.method1()
+      const duration = performance.now() - startTime
 
       // Verify that we got the result from the fast implementation
-      expect(result).toBe("fast");
+      expect(result).toBe('fast')
 
       // Verify that the duration is more than 300ms (way slower than the time of the fast implementation)
       // As we are waiting for the slow implementation to complete
-      expect(duration).toBeGreaterThanOrEqual(300);
-    });
+      expect(duration).toBeGreaterThanOrEqual(300)
+    })
 
-    it("WILL throw errors from the primary implementation directly to the caller", async () => {
+    it('WILL throw errors from the primary implementation directly to the caller', async () => {
       // Create an implementation that throws an error
       const errorImpl = {
         method1: async () => {
-          throw new Error("Primary implementation error");
+          throw new Error('Primary implementation error')
         },
-        method2: async () => "method2",
-        method3: async () => "method3",
-      };
+        method2: async () => 'method2',
+        method3: async () => 'method3',
+      }
 
       // Create a normal implementation
       const normalImpl = {
         method1: async () => {
-          return "normal";
+          return 'normal'
         },
-        method2: async () => "method2",
-        method3: async () => "method3",
-      };
+        method2: async () => 'method2',
+        method3: async () => 'method3',
+      }
 
       // Test with old-compare mode (using the implementation that throws)
-      featureFlag = async () => "old-compare";
+      featureFlag = async () => 'old-compare'
       const service = Strangler(
         featureFlag,
         normalImpl as any, // new implementation (not used for result)
-        errorImpl as any // old implementation (throws error)
-      );
+        errorImpl as any, // old implementation (throws error)
+      )
 
       // Verify that the error is thrown to the caller
-      await expect(service.method1()).rejects.toThrow(
-        "Primary implementation error"
-      );
-    });
+      await expect(service.method1()).rejects.toThrow('Primary implementation error')
+    })
 
-    it("IF a parallel compare service fails, the onCompare function will be called with the error as the result.", async () => {
+    it('IF a parallel compare service fails, the onCompare function will be called with the error as the result.', async () => {
       const oldImpl = {
-        method1: async () => "old",
-      };
+        method1: async () => 'old',
+      }
       const newImpl = {
         method1: async () => {
-          throw new Error("New implementation failed");
+          throw new Error('New implementation failed')
         },
-      };
+      }
 
-      const comparisons: any[] = [];
+      const comparisons: any[] = []
 
       // Create a promise that will resolve when onComparison is called
-      let resolveComparisonPromise: () => void;
+      let resolveComparisonPromise: () => void
       const comparisonPromise = new Promise<void>((resolve) => {
-        resolveComparisonPromise = resolve;
-      });
+        resolveComparisonPromise = resolve
+      })
 
       const service = Strangler(
-        async () => "old-compare",
+        async () => 'old-compare',
         newImpl,
         oldImpl,
         (comparison) => {
-          comparisons.push(comparison);
-          resolveComparisonPromise();
-        }
-      );
+          comparisons.push(comparison)
+          resolveComparisonPromise()
+        },
+      )
 
-      const result = await service.method1();
+      const result = await service.method1()
 
       // Wait for the comparison to be completed
-      await comparisonPromise;
+      await comparisonPromise
 
-      expect(result).toBe("old");
-      expect(comparisons).toHaveLength(1);
+      expect(result).toBe('old')
+      expect(comparisons).toHaveLength(1)
       expect(comparisons[0]).toEqual(
         expect.objectContaining({
-          oldResult: "old",
-          newResult: new Error("New implementation failed"),
-        })
-      );
-    });
+          oldResult: 'old',
+          newResult: new Error('New implementation failed'),
+        }),
+      )
+    })
 
-    it("WILL include the equality metadata in the onComparison result.", async () => {
-      const comparisons: any[] = [];
-      featureFlag = async () => "new-compare";
+    it('WILL include the equality metadata in the onComparison result.', async () => {
+      const comparisons: any[] = []
+      featureFlag = async () => 'new-compare'
 
       // Create a promise that will resolve when onComparison is called
-      let resolveComparisonPromise: () => void;
+      let resolveComparisonPromise: () => void
       const comparisonPromise = new Promise<void>((resolve) => {
-        resolveComparisonPromise = resolve;
-      });
+        resolveComparisonPromise = resolve
+      })
 
       const service = Strangler(
         featureFlag,
         newImpl,
         oldImpl,
         (comparison) => {
-          comparisons.push(comparison);
-          resolveComparisonPromise();
+          comparisons.push(comparison)
+          resolveComparisonPromise()
         },
         {
           equalityFn: (a, b) => ({
             isEqual: a === b,
             metadata: {
-              failingPath: "createdBy",
-              scheduleId: "123",
+              failingPath: 'createdBy',
+              scheduleId: '123',
             },
           }),
-        }
-      );
+        },
+      )
 
-      const result = await service.method1();
+      const result = await service.method1()
 
       // Wait for the comparison to be completed
-      await comparisonPromise;
+      await comparisonPromise
 
-      expect(comparisons).toHaveLength(1);
+      expect(comparisons).toHaveLength(1)
       expect(comparisons[0]).toMatchObject({
-        oldResult: "old",
-        newResult: "new",
-        methodName: "method1",
-      });
-      expect(result).toBe("new");
+        oldResult: 'old',
+        newResult: 'new',
+        methodName: 'method1',
+      })
+      expect(result).toBe('new')
       expect(comparisons[0].equalityMetadata).toEqual({
-        failingPath: "createdBy",
-        scheduleId: "123",
-      });
-    });
-  });
-  describe("Configuration Features.", () => {
-    it("WILL support configuring the performance threshold", async () => {
+        failingPath: 'createdBy',
+        scheduleId: '123',
+      })
+    })
+  })
+  describe('Configuration Features.', () => {
+    it('WILL support configuring the performance threshold', async () => {
       // This is covered by the 'Comparison Features' test cases.
-      return;
-    });
-  });
-  describe("Error Scenarios", () => {
+      return
+    })
+  })
+  describe('Error Scenarios', () => {
     it('WILL log an error and revert to "old", if the feature flag returns an unknown value', async () => {
       const oldImpl = {
-        method1: async () => "old",
-      };
+        method1: async () => 'old',
+      }
       const newImpl = {
-        method1: async () => "new",
-      };
+        method1: async () => 'new',
+      }
 
-      const featureFlag = async () => "invalid-mode" as StranglerMode;
-      const errors: any[] = [];
-      const errorLogger = (error: Error) => errors.push(error);
+      const featureFlag = async () => 'invalid-mode' as StranglerMode
+      const errors: any[] = []
+      const errorLogger = (error: Error) => errors.push(error)
 
       const service = Strangler(featureFlag, newImpl, oldImpl, undefined, {
         logger: {
           error: errorLogger,
         },
-      });
+      })
 
-      const result = await service.method1();
+      const result = await service.method1()
 
-      expect(result).toBe("old");
-      expect(errors).toHaveLength(1);
-      expect(errors[0].message).toContain(
-        "Invalid StranglerMode: invalid-mode"
-      );
-    });
-    it("IF a parallel compare service fails (but is not used for response), DO NOT fail the response.", async () => {
+      expect(result).toBe('old')
+      expect(errors).toHaveLength(1)
+      expect(errors[0].message).toContain('Invalid StranglerMode: invalid-mode')
+    })
+    it('IF a parallel compare service fails (but is not used for response), DO NOT fail the response.', async () => {
       const oldImpl = {
-        method1: async () => "old",
-      };
+        method1: async () => 'old',
+      }
       const newImpl = {
         method1: async () => {
-          throw new Error("New implementation failed");
+          throw new Error('New implementation failed')
         },
-      };
+      }
 
-      let featureFlag = "old-compare";
-      const comparisons: any[] = [];
+      let featureFlag = 'old-compare'
+      const comparisons: any[] = []
 
       const service = Strangler(
         async () => featureFlag,
         newImpl,
         oldImpl,
         (comparison) => {
-          comparisons.push(comparison);
-        }
-      );
+          comparisons.push(comparison)
+        },
+      )
 
-      const result = await service.method1();
-      expect(result).toBe("old");
+      const result = await service.method1()
+      expect(result).toBe('old')
 
-      featureFlag = "new-compare";
-      expect(service.method1()).rejects.toThrow();
-    });
-    it("IF a parallel compare service fails (waited, but not used for response), DO NOT fail the response.", async () => {
+      featureFlag = 'new-compare'
+      expect(service.method1()).rejects.toThrow()
+    })
+    it('IF a parallel compare service fails (waited, but not used for response), DO NOT fail the response.', async () => {
       const oldImpl = {
-        method1: async () => "old",
-      };
+        method1: async () => 'old',
+      }
       const newImpl = {
         method1: async () => {
-          throw new Error("New implementation failed");
+          throw new Error('New implementation failed')
         },
-      };
+      }
 
-      let featureFlag = "old-compare";
-      const comparisons: any[] = [];
+      let featureFlag = 'old-compare'
+      const comparisons: any[] = []
 
       const service = Strangler(
         async () => featureFlag,
         newImpl,
         oldImpl,
         (comparison) => {
-          comparisons.push(comparison);
+          comparisons.push(comparison)
         },
         {
           waitForComparison: true,
-        }
-      );
+        },
+      )
 
-      const result = await service.method1();
-      expect(result).toBe("old");
+      const result = await service.method1()
+      expect(result).toBe('old')
 
-      featureFlag = "new-compare";
-      expect(service.method1()).rejects.toThrow();
-    });
-    it("IF a parallel compare service fails, the onCompare function will be called with the error as the result.", async () => {
+      featureFlag = 'new-compare'
+      expect(service.method1()).rejects.toThrow()
+    })
+    it('IF a parallel compare service fails, the onCompare function will be called with the error as the result.', async () => {
       const oldImpl = {
-        method1: async () => "old",
-      };
+        method1: async () => 'old',
+      }
       const newImpl = {
         method1: async () => {
-          throw new Error("New implementation failed");
+          throw new Error('New implementation failed')
         },
-      };
+      }
 
-      const comparisons: any[] = [];
+      const comparisons: any[] = []
 
       // Create a promise that will resolve when onComparison is called
-      let resolveComparisonPromise: () => void;
+      let resolveComparisonPromise: () => void
       const comparisonPromise = new Promise<void>((resolve) => {
-        resolveComparisonPromise = resolve;
-      });
+        resolveComparisonPromise = resolve
+      })
 
       const service = Strangler(
-        async () => "old-compare",
+        async () => 'old-compare',
         newImpl,
         oldImpl,
         (comparison) => {
-          comparisons.push(comparison);
-          resolveComparisonPromise();
-        }
-      );
+          comparisons.push(comparison)
+          resolveComparisonPromise()
+        },
+      )
 
-      const result = await service.method1();
+      const result = await service.method1()
 
-      await comparisonPromise;
+      await comparisonPromise
 
-      expect(result).toBe("old");
-      expect(comparisons).toHaveLength(1);
+      expect(result).toBe('old')
+      expect(comparisons).toHaveLength(1)
       expect(comparisons[0]).toEqual(
         expect.objectContaining({
-          oldResult: "old",
-          newResult: new Error("New implementation failed"),
-        })
-      );
-    });
+          oldResult: 'old',
+          newResult: new Error('New implementation failed'),
+        }),
+      )
+    })
 
-    it("IF equality function throws, do not fail the response.", async () => {
+    it('IF equality function throws, do not fail the response.', async () => {
       const oldImpl = {
-        method1: async () => "old",
-      };
+        method1: async () => 'old',
+      }
       const newImpl = {
-        method1: async () => "new",
-      };
+        method1: async () => 'new',
+      }
+
+      const service = Strangler(async () => 'new-compare', newImpl, oldImpl, undefined, {
+        equalityFn: () => {
+          throw new Error('Equality function failed')
+        },
+      })
+
+      const result = await service.method1()
+      expect(result).toBe('new')
+    })
+
+    it('IF comparison function throws, do not fail the response.', async () => {
+      const oldImpl = {
+        method1: async () => 'old',
+      }
+      const newImpl = {
+        method1: async () => 'new',
+      }
 
       const service = Strangler(
-        async () => "new-compare",
-        newImpl,
-        oldImpl,
-        undefined,
-        {
-          equalityFn: () => {
-            throw new Error("Equality function failed");
-          },
-        }
-      );
-
-      const result = await service.method1();
-      expect(result).toBe("new");
-    });
-
-    it("IF comparison function throws, do not fail the response.", async () => {
-      const oldImpl = {
-        method1: async () => "old",
-      };
-      const newImpl = {
-        method1: async () => "new",
-      };
-
-      const service = Strangler(
-        async () => "new-compare",
+        async () => 'new-compare',
         newImpl,
         oldImpl,
         () => {
-          throw new Error("Comparison function failed");
+          throw new Error('Comparison function failed')
         },
         {
           logger: mockLogger,
-        }
-      );
+        },
+      )
 
-      const result = await service.method1();
-      expect(result).toBe("new");
-    });
-  });
-});
+      const result = await service.method1()
+      expect(result).toBe('new')
+    })
+  })
+})

--- a/src/strangler.spec.ts
+++ b/src/strangler.spec.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach } from "vitest";
 import {
   type AsyncFunction,
   type AsyncService,
   type FeatureFlag,
   Strangler,
   type StranglerMode,
-} from './strangler'
+} from "./strangler";
 
 // Mock logger that doesn't output anything
 const mockLogger = {
@@ -14,357 +14,371 @@ const mockLogger = {
   info: () => {},
   log: () => {},
   debug: () => {},
-}
+};
 
 type TestService = AsyncService & {
-  method1: (text?: string, value?: number) => Promise<string>
-  method2: () => Promise<string>
-  method3: () => Promise<string>
-}
+  method1: (text?: string, value?: number) => Promise<string>;
+  method2: () => Promise<string>;
+  method3: () => Promise<string>;
+};
 
-describe('Strangler', () => {
-  describe('Basic Features', () => {
+describe("Strangler", () => {
+  describe("Basic Features", () => {
     // Not specifying the types allows us to also test type inference of `Strangler` arguments.
     const oldImpl = {
-      method1: async () => 'old',
-      method2: async () => 'old2',
-      method3: async () => 'old3',
-    }
+      method1: async () => "old",
+      method2: async () => "old2",
+      method3: async () => "old3",
+    };
 
     const newImpl = {
-      method1: async () => 'new',
-      method2: async () => 'new2',
-    }
+      method1: async () => "new",
+      method2: async () => "new2",
+    };
 
-    it('WILL allow runtime toggling between two implementations', async () => {
-      let flagValue: StranglerMode = 'old'
-      const featureFlag = async () => flagValue
-      const service = Strangler(featureFlag, newImpl, oldImpl)
+    it("WILL allow runtime toggling between two implementations", async () => {
+      let flagValue: StranglerMode = "old";
+      const featureFlag = async () => flagValue;
+      const service = Strangler(featureFlag, newImpl, oldImpl);
 
-      expect(await service.method1()).toBe('old')
-      flagValue = 'new'
-      expect(await service.method1()).toBe('new')
-    })
+      expect(await service.method1()).toBe("old");
+      flagValue = "new";
+      expect(await service.method1()).toBe("new");
+    });
 
-    it('WILL allow toggling by individual method', async () => {
-      const featureFlag: FeatureFlag = async () => 'new'
+    it("WILL allow toggling by individual method", async () => {
+      const featureFlag: FeatureFlag = async () => "new";
       const service = Strangler(
         featureFlag,
         {
           method1: oldImpl.method1,
           method2: newImpl.method2,
         },
-        oldImpl,
-      )
+        oldImpl
+      );
 
-      expect(await service.method1()).toBe('old')
-      expect(await service.method2()).toBe('new2')
-    })
+      expect(await service.method1()).toBe("old");
+      expect(await service.method2()).toBe("new2");
+    });
 
-    it('Methods that are not implemented in the NEW service are called in the OLD service', async () => {
-      const featureFlag: FeatureFlag = async () => 'new'
-      const service = Strangler(featureFlag, newImpl, oldImpl)
+    it("Methods that are not implemented in the NEW service are called in the OLD service", async () => {
+      const featureFlag: FeatureFlag = async () => "new";
+      const service = Strangler(featureFlag, newImpl, oldImpl);
 
-      const result = await service.method3?.()
-      expect(result).toBe('old3')
-    })
-  })
+      const result = await service.method3?.();
+      expect(result).toBe("old3");
+    });
+  });
 
-  describe('Basic Features (with classes)', () => {
+  describe("Basic Features (with classes)", () => {
     class OldImpl implements TestService {
-      [key: string]: AsyncFunction | unknown
-      instanceVariable = 'old'
+      [key: string]: AsyncFunction | unknown;
+      instanceVariable = "old";
       async method1() {
-        return this.instanceVariable
+        return this.instanceVariable;
       }
       async method2() {
-        return 'old2'
+        return "old2";
       }
       async method3() {
-        return 'old3'
+        return "old3";
       }
     }
-    const oldImpl = new OldImpl()
+    const oldImpl = new OldImpl();
 
     class NewImpl implements Partial<TestService> {
-      [key: string]: AsyncFunction | unknown
-      instanceVariable = 'new'
+      [key: string]: AsyncFunction | unknown;
+      instanceVariable = "new";
       async method1() {
-        return this.instanceVariable
+        return this.instanceVariable;
       }
       async method2() {
-        return 'new2'
+        return "new2";
       }
     }
-    const newImpl = new NewImpl()
+    const newImpl = new NewImpl();
 
-    it('WILL allow runtime toggling between two implementations', async () => {
-      let flagValue: StranglerMode = 'old'
-      const featureFlag = async () => flagValue
-      const service = Strangler(featureFlag, newImpl, oldImpl)
+    it("WILL allow runtime toggling between two implementations", async () => {
+      let flagValue: StranglerMode = "old";
+      const featureFlag = async () => flagValue;
+      const service = Strangler(featureFlag, newImpl, oldImpl);
 
-      expect(await service.method1()).toBe('old')
-      flagValue = 'new'
-      expect(await service.method1()).toBe('new')
-    })
+      expect(await service.method1()).toBe("old");
+      flagValue = "new";
+      expect(await service.method1()).toBe("new");
+    });
 
-    it('WILL allow toggling by individual method', async () => {
-      const featureFlag: FeatureFlag = async () => 'new'
+    it("WILL allow toggling by individual method", async () => {
+      const featureFlag: FeatureFlag = async () => "new";
       class NewImpl2 implements TestService {
-        instanceVariable = 'old'
+        instanceVariable = "old";
         async method1() {
-          return this.instanceVariable
+          return this.instanceVariable;
         }
         async method2() {
-          return 'new2'
+          return "new2";
         }
         async method3() {
-          return 'new3'
+          return "new3";
         }
       }
-      const newImpl2 = new NewImpl2()
-      const service = Strangler(featureFlag, newImpl2, oldImpl)
+      const newImpl2 = new NewImpl2();
+      const service = Strangler(featureFlag, newImpl2, oldImpl);
 
-      expect(await service.method1()).toBe('old')
-      expect(await service.method2()).toBe('new2')
-    })
+      expect(await service.method1()).toBe("old");
+      expect(await service.method2()).toBe("new2");
+    });
 
-    it('Methods that are not implemented in the NEW service are called in the OLD service', async () => {
-      const featureFlag: FeatureFlag = async () => 'new'
-      const service = Strangler<TestService, keyof TestService>(featureFlag, newImpl, oldImpl)
+    it("Methods that are not implemented in the NEW service are called in the OLD service", async () => {
+      const featureFlag: FeatureFlag = async () => "new";
+      const service = Strangler<TestService, keyof TestService>(
+        featureFlag,
+        newImpl,
+        oldImpl
+      );
 
-      const result = await service.method3()
-      expect(result).toBe('old3')
-    })
-  })
-  describe('Comparison Features', () => {
-    let oldImpl: Omit<TestService, 'method3'>
-    let newImpl: Omit<TestService, 'method3'>
-    let featureFlag: FeatureFlag
+      const result = await service.method3();
+      expect(result).toBe("old3");
+    });
+  });
+  describe("Comparison Features", () => {
+    let oldImpl: Omit<TestService, "method3">;
+    let newImpl: Omit<TestService, "method3">;
+    let featureFlag: FeatureFlag;
 
     beforeEach(() => {
       oldImpl = {
-        method1: async () => 'old',
-        method2: async () => 'old2',
-      }
+        method1: async () => "old",
+        method2: async () => "old2",
+      };
       newImpl = {
-        method1: async () => 'new',
-        method2: async () => 'new2',
-      }
-      featureFlag = async () => 'old'
-    })
+        method1: async () => "new",
+        method2: async () => "new2",
+      };
+      featureFlag = async () => "old";
+    });
 
-    it('WILL execute both implementations, and compare their return values', async () => {
-      const comparisons: any[] = []
-      featureFlag = async () => 'new-compare'
+    it("WILL execute both implementations, and compare their return values", async () => {
+      const comparisons: any[] = [];
+      featureFlag = async () => "new-compare";
 
       // Create a promise that will resolve when onComparison is called
-      let resolveComparisonPromise: () => void
+      let resolveComparisonPromise: () => void;
       const comparisonPromise = new Promise<void>((resolve) => {
-        resolveComparisonPromise = resolve
-      })
+        resolveComparisonPromise = resolve;
+      });
 
       const service = Strangler(featureFlag, newImpl, oldImpl, (comparison) => {
-        comparisons.push(comparison)
-        resolveComparisonPromise()
-      })
+        comparisons.push(comparison);
+        resolveComparisonPromise();
+      });
 
-      const result = await service.method1()
+      const result = await service.method1();
 
       // Wait for the comparison to be completed
-      await comparisonPromise
+      await comparisonPromise;
 
-      expect(comparisons).toHaveLength(1)
+      expect(comparisons).toHaveLength(1);
       expect(comparisons[0]).toMatchObject({
-        oldResult: 'old',
-        newResult: 'new',
-        methodName: 'method1',
-      })
-      expect(result).toBe('new')
-    })
+        oldResult: "old",
+        newResult: "new",
+        methodName: "method1",
+      });
+      expect(result).toBe("new");
+    });
 
-    it('WILL execute both implementations, and compare their performance', async () => {
+    it("WILL execute both implementations, and compare their performance", async () => {
       const slowNewImpl = {
         method1: async () => {
-          await new Promise((resolve) => setTimeout(resolve, 50))
-          return 'new'
+          await new Promise((resolve) => setTimeout(resolve, 50));
+          return "new";
         },
-        method2: async () => 'method2',
-        method3: async () => 'method3',
-      }
+        method2: async () => "method2",
+        method3: async () => "method3",
+      };
 
-      const comparisons: any[] = []
-      featureFlag = async () => 'old-compare'
+      const comparisons: any[] = [];
+      featureFlag = async () => "old-compare";
 
       // Create a promise that will resolve when onComparison is called
-      let resolveComparisonPromise: () => void
+      let resolveComparisonPromise: () => void;
       const comparisonPromise = new Promise<void>((resolve) => {
-        resolveComparisonPromise = resolve
-      })
+        resolveComparisonPromise = resolve;
+      });
 
       const service = Strangler(
         featureFlag,
         slowNewImpl,
         oldImpl,
         (comparison) => {
-          comparisons.push(comparison)
-          resolveComparisonPromise()
+          comparisons.push(comparison);
+          resolveComparisonPromise();
         },
         {
           acceptableDurationDifference: 0, // Always log.
-        },
-      )
+        }
+      );
 
-      const result = await service.method1()
+      const result = await service.method1();
 
       // Wait for the comparison to be completed
-      await comparisonPromise
+      await comparisonPromise;
 
-      expect(comparisons).toHaveLength(1)
-      expect(comparisons[0].newDuration).toBeGreaterThan(45)
-      expect(comparisons[0].oldDuration).toBeLessThan(45)
-      expect(result).toBe('old')
-    })
+      expect(comparisons).toHaveLength(1);
+      expect(comparisons[0].newDuration).toBeGreaterThan(45);
+      expect(comparisons[0].oldDuration).toBeLessThan(45);
+      expect(result).toBe("old");
+    });
 
-    it('IF the values are not different, nothing is logged', async () => {
+    it("IF the values are not different, nothing is logged", async () => {
       const sameImpl = {
-        method1: async () => 'same',
-        method2: async () => 'method2',
-        method3: async () => 'method3',
-      }
+        method1: async () => "same",
+        method2: async () => "method2",
+        method3: async () => "method3",
+      };
 
-      const comparisons: any[] = []
-      featureFlag = async () => 'new-compare'
-      const service = Strangler(featureFlag, sameImpl, sameImpl, (comparison) => {
-        comparisons.push(comparison)
-      })
+      const comparisons: any[] = [];
+      featureFlag = async () => "new-compare";
+      const service = Strangler(
+        featureFlag,
+        sameImpl,
+        sameImpl,
+        (comparison) => {
+          comparisons.push(comparison);
+        }
+      );
 
-      await service.method1()
-      expect(comparisons).toHaveLength(0)
-    })
+      await service.method1();
+      expect(comparisons).toHaveLength(0);
+    });
 
-    it('IF the durations do not differ by more than the predefined threshold, nothing is logged', async () => {
+    it("IF the durations do not differ by more than the predefined threshold, nothing is logged", async () => {
       const fastImpl = {
-        method1: async () => 'fast',
-        method2: async () => 'method2',
-        method3: async () => 'method3',
-      }
+        method1: async () => "fast",
+        method2: async () => "method2",
+        method3: async () => "method3",
+      };
 
-      const comparisons: any[] = []
-      featureFlag = async () => 'new-compare'
+      const comparisons: any[] = [];
+      featureFlag = async () => "new-compare";
       const service = Strangler(
         featureFlag,
         fastImpl,
         { ...fastImpl },
         (comparison) => {
-          comparisons.push(comparison)
+          comparisons.push(comparison);
         },
-        { acceptableDurationDifference: 1000 },
-      )
+        { acceptableDurationDifference: 1000 }
+      );
 
-      await service.method1()
-      expect(comparisons).toHaveLength(0)
-    })
+      await service.method1();
+      expect(comparisons).toHaveLength(0);
+    });
 
-    it('WILL NOT compare implementations when not in compare mode', async () => {
-      for (const mode of ['old', 'new']) {
-        const comparisons: unknown[] = []
-        const featureFlag = async () => mode as StranglerMode
-        const service = Strangler(featureFlag, newImpl, oldImpl, (comparison) => {
-          comparisons.push(comparison)
-        })
+    it("WILL NOT compare implementations when not in compare mode", async () => {
+      for (const mode of ["old", "new"]) {
+        const comparisons: unknown[] = [];
+        const featureFlag = async () => mode as StranglerMode;
+        const service = Strangler(
+          featureFlag,
+          newImpl,
+          oldImpl,
+          (comparison) => {
+            comparisons.push(comparison);
+          }
+        );
 
-        expect(await service.method1()).toBe(mode)
+        expect(await service.method1()).toBe(mode);
       }
-    })
+    });
 
-    it('WILL include all arguments in the OnComparison result.', async () => {
-      const comparisons: any[] = []
-      featureFlag = async () => 'new-compare'
+    it("WILL include all arguments in the OnComparison result.", async () => {
+      const comparisons: any[] = [];
+      featureFlag = async () => "new-compare";
 
       // Create a promise that will resolve when onComparison is called
-      let resolveComparisonPromise: () => void
+      let resolveComparisonPromise: () => void;
       const comparisonPromise = new Promise<void>((resolve) => {
-        resolveComparisonPromise = resolve
-      })
+        resolveComparisonPromise = resolve;
+      });
 
       const service = Strangler(featureFlag, newImpl, oldImpl, (comparison) => {
-        comparisons.push(comparison)
-        resolveComparisonPromise()
-      })
+        comparisons.push(comparison);
+        resolveComparisonPromise();
+      });
 
-      await service.method1('test', 123)
+      await service.method1("test", 123);
 
       // Wait for the comparison to be completed
-      await comparisonPromise
+      await comparisonPromise;
 
-      expect(comparisons[0].parameters).toEqual(['test', 123])
-    })
+      expect(comparisons[0].parameters).toEqual(["test", 123]);
+    });
 
-    it('WILL NOT wait for the slowest of the two operations to complete before returning the one in use.', async () => {
+    it("WILL NOT wait for the slowest of the two operations to complete before returning the one in use.", async () => {
       // Create a very slow implementation
       const verySlowImpl = {
         method1: async () => {
-          await new Promise((resolve) => setTimeout(resolve, 500))
-          return 'very-slow'
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          return "very-slow";
         },
-        method2: async () => 'method2',
-        method3: async () => 'method3',
-      }
+        method2: async () => "method2",
+        method3: async () => "method3",
+      };
 
       // Create a fast implementation
       const fastImpl = {
         method1: async () => {
-          return 'fast'
+          return "fast";
         },
-        method2: async () => 'method2',
-        method3: async () => 'method3',
-      }
+        method2: async () => "method2",
+        method3: async () => "method3",
+      };
 
       // Test with old-compare mode (using the fast implementation)
-      featureFlag = async () => 'old-compare'
+      featureFlag = async () => "old-compare";
       const service = Strangler(
         featureFlag,
         verySlowImpl, // new implementation (slow)
         fastImpl, // old implementation (fast)
-        () => {}, // empty comparison function
-      )
+        () => {} // empty comparison function
+      );
 
       // Measure how long it takes to get the result
-      const startTime = performance.now()
-      const result = await service.method1()
-      const duration = performance.now() - startTime
+      const startTime = performance.now();
+      const result = await service.method1();
+      const duration = performance.now() - startTime;
 
       // Verify that we got the result from the fast implementation
-      expect(result).toBe('fast')
+      expect(result).toBe("fast");
 
       // Verify that the duration is much less than 500ms (the time of the slow implementation)
       // We allow some buffer time for test execution overhead
-      expect(duration).toBeLessThan(300)
-    })
+      expect(duration).toBeLessThan(300);
+    });
 
-    it('WILL wait for the slowest of the two operations to complete before returning the one in use if requested in the options', async () => {
+    it("WILL wait for the slowest of the two operations to complete before returning the one in use if requested in the options", async () => {
       // Create a very slow implementation
       const verySlowImpl = {
         method1: async () => {
-          await new Promise((resolve) => setTimeout(resolve, 500))
-          return 'very-slow'
+          await new Promise((resolve) => setTimeout(resolve, 500));
+          return "very-slow";
         },
-        method2: async () => 'method2',
-        method3: async () => 'method3',
-      }
+        method2: async () => "method2",
+        method3: async () => "method3",
+      };
 
       // Create a fast implementation
       const fastImpl = {
         method1: async () => {
-          return 'fast'
+          return "fast";
         },
-        method2: async () => 'method2',
-        method3: async () => 'method3',
-      }
+        method2: async () => "method2",
+        method3: async () => "method3",
+      };
 
       // Test with old-compare mode (using the fast implementation)
-      featureFlag = async () => 'old-compare'
+      featureFlag = async () => "old-compare";
       const service = Strangler(
         featureFlag,
         verySlowImpl, // new implementation (slow)
@@ -372,268 +386,325 @@ describe('Strangler', () => {
         () => {}, // empty comparison function
         {
           waitForComparison: true,
-        },
-      )
+        }
+      );
 
       // Measure how long it takes to get the result
-      const startTime = performance.now()
-      const result = await service.method1()
-      const duration = performance.now() - startTime
+      const startTime = performance.now();
+      const result = await service.method1();
+      const duration = performance.now() - startTime;
 
       // Verify that we got the result from the fast implementation
-      expect(result).toBe('fast')
+      expect(result).toBe("fast");
 
       // Verify that the duration is more than 300ms (way slower than the time of the fast implementation)
       // As we are waiting for the slow implementation to complete
-      expect(duration).toBeGreaterThanOrEqual(300)
-    })
+      expect(duration).toBeGreaterThanOrEqual(300);
+    });
 
-    it('WILL throw errors from the primary implementation directly to the caller', async () => {
+    it("WILL throw errors from the primary implementation directly to the caller", async () => {
       // Create an implementation that throws an error
       const errorImpl = {
         method1: async () => {
-          throw new Error('Primary implementation error')
+          throw new Error("Primary implementation error");
         },
-        method2: async () => 'method2',
-        method3: async () => 'method3',
-      }
+        method2: async () => "method2",
+        method3: async () => "method3",
+      };
 
       // Create a normal implementation
       const normalImpl = {
         method1: async () => {
-          return 'normal'
+          return "normal";
         },
-        method2: async () => 'method2',
-        method3: async () => 'method3',
-      }
+        method2: async () => "method2",
+        method3: async () => "method3",
+      };
 
       // Test with old-compare mode (using the implementation that throws)
-      featureFlag = async () => 'old-compare'
+      featureFlag = async () => "old-compare";
       const service = Strangler(
         featureFlag,
         normalImpl as any, // new implementation (not used for result)
-        errorImpl as any, // old implementation (throws error)
-      )
+        errorImpl as any // old implementation (throws error)
+      );
 
       // Verify that the error is thrown to the caller
-      await expect(service.method1()).rejects.toThrow('Primary implementation error')
-    })
+      await expect(service.method1()).rejects.toThrow(
+        "Primary implementation error"
+      );
+    });
 
-    it('IF a parallel compare service fails, the onCompare function will be called with the error as the result.', async () => {
+    it("IF a parallel compare service fails, the onCompare function will be called with the error as the result.", async () => {
       const oldImpl = {
-        method1: async () => 'old',
-      }
+        method1: async () => "old",
+      };
       const newImpl = {
         method1: async () => {
-          throw new Error('New implementation failed')
+          throw new Error("New implementation failed");
         },
-      }
+      };
 
-      const comparisons: any[] = []
+      const comparisons: any[] = [];
 
       // Create a promise that will resolve when onComparison is called
-      let resolveComparisonPromise: () => void
+      let resolveComparisonPromise: () => void;
       const comparisonPromise = new Promise<void>((resolve) => {
-        resolveComparisonPromise = resolve
-      })
+        resolveComparisonPromise = resolve;
+      });
 
       const service = Strangler(
-        async () => 'old-compare',
+        async () => "old-compare",
         newImpl,
         oldImpl,
         (comparison) => {
-          comparisons.push(comparison)
-          resolveComparisonPromise()
-        },
-      )
+          comparisons.push(comparison);
+          resolveComparisonPromise();
+        }
+      );
 
-      const result = await service.method1()
+      const result = await service.method1();
 
       // Wait for the comparison to be completed
-      await comparisonPromise
+      await comparisonPromise;
 
-      expect(result).toBe('old')
-      expect(comparisons).toHaveLength(1)
+      expect(result).toBe("old");
+      expect(comparisons).toHaveLength(1);
       expect(comparisons[0]).toEqual(
         expect.objectContaining({
-          oldResult: 'old',
-          newResult: new Error('New implementation failed'),
-        }),
-      )
-    })
-  })
-  describe('Configuration Features.', () => {
-    it('WILL support configuring the performance threshold', async () => {
+          oldResult: "old",
+          newResult: new Error("New implementation failed"),
+        })
+      );
+    });
+
+    it("WILL include the equality metadata in the onComparison result.", async () => {
+      const comparisons: any[] = [];
+      featureFlag = async () => "new-compare";
+
+      // Create a promise that will resolve when onComparison is called
+      let resolveComparisonPromise: () => void;
+      const comparisonPromise = new Promise<void>((resolve) => {
+        resolveComparisonPromise = resolve;
+      });
+
+      const service = Strangler(
+        featureFlag,
+        newImpl,
+        oldImpl,
+        (comparison) => {
+          comparisons.push(comparison);
+          resolveComparisonPromise();
+        },
+        {
+          equalityFn: (a, b) => ({
+            isEqual: a === b,
+            metadata: {
+              failingPath: "createdBy",
+              scheduleId: "123",
+            },
+          }),
+        }
+      );
+
+      const result = await service.method1();
+
+      // Wait for the comparison to be completed
+      await comparisonPromise;
+
+      expect(comparisons).toHaveLength(1);
+      expect(comparisons[0]).toMatchObject({
+        oldResult: "old",
+        newResult: "new",
+        methodName: "method1",
+      });
+      expect(result).toBe("new");
+      expect(comparisons[0].equalityMetadata).toEqual({
+        failingPath: "createdBy",
+        scheduleId: "123",
+      });
+    });
+  });
+  describe("Configuration Features.", () => {
+    it("WILL support configuring the performance threshold", async () => {
       // This is covered by the 'Comparison Features' test cases.
-      return
-    })
-  })
-  describe('Error Scenarios', () => {
+      return;
+    });
+  });
+  describe("Error Scenarios", () => {
     it('WILL log an error and revert to "old", if the feature flag returns an unknown value', async () => {
       const oldImpl = {
-        method1: async () => 'old',
-      }
+        method1: async () => "old",
+      };
       const newImpl = {
-        method1: async () => 'new',
-      }
+        method1: async () => "new",
+      };
 
-      const featureFlag = async () => 'invalid-mode' as StranglerMode
-      const errors: any[] = []
-      const errorLogger = (error: Error) => errors.push(error)
+      const featureFlag = async () => "invalid-mode" as StranglerMode;
+      const errors: any[] = [];
+      const errorLogger = (error: Error) => errors.push(error);
 
       const service = Strangler(featureFlag, newImpl, oldImpl, undefined, {
         logger: {
           error: errorLogger,
         },
-      })
+      });
 
-      const result = await service.method1()
+      const result = await service.method1();
 
-      expect(result).toBe('old')
-      expect(errors).toHaveLength(1)
-      expect(errors[0].message).toContain('Invalid StranglerMode: invalid-mode')
-    })
-    it('IF a parallel compare service fails (but is not used for response), DO NOT fail the response.', async () => {
+      expect(result).toBe("old");
+      expect(errors).toHaveLength(1);
+      expect(errors[0].message).toContain(
+        "Invalid StranglerMode: invalid-mode"
+      );
+    });
+    it("IF a parallel compare service fails (but is not used for response), DO NOT fail the response.", async () => {
       const oldImpl = {
-        method1: async () => 'old',
-      }
+        method1: async () => "old",
+      };
       const newImpl = {
         method1: async () => {
-          throw new Error('New implementation failed')
+          throw new Error("New implementation failed");
         },
-      }
+      };
 
-      let featureFlag = 'old-compare'
-      const comparisons: any[] = []
+      let featureFlag = "old-compare";
+      const comparisons: any[] = [];
 
       const service = Strangler(
         async () => featureFlag,
         newImpl,
         oldImpl,
         (comparison) => {
-          comparisons.push(comparison)
-        },
-      )
+          comparisons.push(comparison);
+        }
+      );
 
-      const result = await service.method1()
-      expect(result).toBe('old')
+      const result = await service.method1();
+      expect(result).toBe("old");
 
-      featureFlag = 'new-compare'
-      expect(service.method1()).rejects.toThrow()
-    })
-    it('IF a parallel compare service fails (waited, but not used for response), DO NOT fail the response.', async () => {
+      featureFlag = "new-compare";
+      expect(service.method1()).rejects.toThrow();
+    });
+    it("IF a parallel compare service fails (waited, but not used for response), DO NOT fail the response.", async () => {
       const oldImpl = {
-        method1: async () => 'old',
-      }
+        method1: async () => "old",
+      };
       const newImpl = {
         method1: async () => {
-          throw new Error('New implementation failed')
+          throw new Error("New implementation failed");
         },
-      }
+      };
 
-      let featureFlag = 'old-compare'
-      const comparisons: any[] = []
+      let featureFlag = "old-compare";
+      const comparisons: any[] = [];
 
       const service = Strangler(
         async () => featureFlag,
         newImpl,
         oldImpl,
         (comparison) => {
-          comparisons.push(comparison)
+          comparisons.push(comparison);
         },
         {
           waitForComparison: true,
-        },
-      )
+        }
+      );
 
-      const result = await service.method1()
-      expect(result).toBe('old')
+      const result = await service.method1();
+      expect(result).toBe("old");
 
-      featureFlag = 'new-compare'
-      expect(service.method1()).rejects.toThrow()
-    })
-    it('IF a parallel compare service fails, the onCompare function will be called with the error as the result.', async () => {
+      featureFlag = "new-compare";
+      expect(service.method1()).rejects.toThrow();
+    });
+    it("IF a parallel compare service fails, the onCompare function will be called with the error as the result.", async () => {
       const oldImpl = {
-        method1: async () => 'old',
-      }
+        method1: async () => "old",
+      };
       const newImpl = {
         method1: async () => {
-          throw new Error('New implementation failed')
+          throw new Error("New implementation failed");
         },
-      }
+      };
 
-      const comparisons: any[] = []
+      const comparisons: any[] = [];
 
       // Create a promise that will resolve when onComparison is called
-      let resolveComparisonPromise: () => void
+      let resolveComparisonPromise: () => void;
       const comparisonPromise = new Promise<void>((resolve) => {
-        resolveComparisonPromise = resolve
-      })
+        resolveComparisonPromise = resolve;
+      });
 
       const service = Strangler(
-        async () => 'old-compare',
+        async () => "old-compare",
         newImpl,
         oldImpl,
         (comparison) => {
-          comparisons.push(comparison)
-          resolveComparisonPromise()
-        },
-      )
+          comparisons.push(comparison);
+          resolveComparisonPromise();
+        }
+      );
 
-      const result = await service.method1()
+      const result = await service.method1();
 
-      await comparisonPromise
+      await comparisonPromise;
 
-      expect(result).toBe('old')
-      expect(comparisons).toHaveLength(1)
+      expect(result).toBe("old");
+      expect(comparisons).toHaveLength(1);
       expect(comparisons[0]).toEqual(
         expect.objectContaining({
-          oldResult: 'old',
-          newResult: new Error('New implementation failed'),
-        }),
-      )
-    })
+          oldResult: "old",
+          newResult: new Error("New implementation failed"),
+        })
+      );
+    });
 
-    it('IF equality function throws, do not fail the response.', async () => {
+    it("IF equality function throws, do not fail the response.", async () => {
       const oldImpl = {
-        method1: async () => 'old',
-      }
+        method1: async () => "old",
+      };
       const newImpl = {
-        method1: async () => 'new',
-      }
-
-      const service = Strangler(async () => 'new-compare', newImpl, oldImpl, undefined, {
-        equalityFn: () => {
-          throw new Error('Equality function failed')
-        },
-      })
-
-      const result = await service.method1()
-      expect(result).toBe('new')
-    })
-
-    it('IF comparison function throws, do not fail the response.', async () => {
-      const oldImpl = {
-        method1: async () => 'old',
-      }
-      const newImpl = {
-        method1: async () => 'new',
-      }
+        method1: async () => "new",
+      };
 
       const service = Strangler(
-        async () => 'new-compare',
+        async () => "new-compare",
+        newImpl,
+        oldImpl,
+        undefined,
+        {
+          equalityFn: () => {
+            throw new Error("Equality function failed");
+          },
+        }
+      );
+
+      const result = await service.method1();
+      expect(result).toBe("new");
+    });
+
+    it("IF comparison function throws, do not fail the response.", async () => {
+      const oldImpl = {
+        method1: async () => "old",
+      };
+      const newImpl = {
+        method1: async () => "new",
+      };
+
+      const service = Strangler(
+        async () => "new-compare",
         newImpl,
         oldImpl,
         () => {
-          throw new Error('Comparison function failed')
+          throw new Error("Comparison function failed");
         },
         {
           logger: mockLogger,
-        },
-      )
+        }
+      );
 
-      const result = await service.method1()
-      expect(result).toBe('new')
-    })
-  })
-})
+      const result = await service.method1();
+      expect(result).toBe("new");
+    });
+  });
+});

--- a/src/strangler.ts
+++ b/src/strangler.ts
@@ -102,7 +102,7 @@ export interface StranglerConfig {
    * The equality function to use to test if results are identical.
    *
    * @default `JSON.stringify(a) === JSON.stringify(b)`
-   *    * @returns `{ isEqual: boolean; metadata: unknown }` where `isEqual` is true if the values are equal, false otherwise.
+   * @returns `{ isEqual: boolean; metadata: unknown }` where `isEqual` is true if the values are equal, false otherwise.
    * `metadata` is additional metadata that can be used to identify the difference.
    */
   equalityFn?: (a: unknown, b: unknown, parameters?: unknown) => OnEqualityResult

--- a/src/strangler.ts
+++ b/src/strangler.ts
@@ -1,8 +1,23 @@
-export type AsyncFunction = (...args: unknown[]) => Promise<unknown>
+export type AsyncFunction = (...args: unknown[]) => Promise<unknown>;
 export type AsyncService = {
   // biome-ignore lint/suspicious/noExplicitAny: TODO: Make these types stricter.
-  [K in keyof any]: K extends string ? AsyncFunction | any : any
-}
+  [K in keyof any]: K extends string ? AsyncFunction | any : any;
+};
+
+/**
+ * The result of the equality function.
+ */
+export type OnEqualityResult = {
+  /**
+   * Whether the values are equal.
+   */
+  isEqual: boolean;
+  /**
+   * Additional metadata that can be used to identify the difference.
+   * Used to pass around data to the onComparison callback in case of difference(s), possibly preventing the need to re-run the equality function in order to log the difference(s).
+   */
+  metadata?: unknown;
+};
 
 /**
  * A callback to be executed during any '-compare' modes.
@@ -15,30 +30,36 @@ export type OnComparison = (comparison: {
    *
    * Can be either a value or an error, if an error was thrown.
    */
-  oldResult: unknown
+  oldResult: unknown;
   /**
    * The 'new' (1st position) implementations result.
    *
    * Can be either a value or an error, if an error was thrown.
    */
-  newResult: unknown
+  newResult: unknown;
   /**
    * 'old' duration in milliseconds.
    */
-  oldDuration: number
+  oldDuration: number;
   /**
    * 'new' duration in milliseconds.
    */
-  newDuration: number
+  newDuration: number;
   /**
    * The name of the method that was invoked.
    */
-  methodName: string
+  methodName: string;
   /**
    * The arguments that were passed to the function.
    */
-  parameters: unknown[]
-}) => void
+  parameters: unknown[];
+
+  /**
+   * Additional metadata that were returned by the equality function.
+   * Often used to pass around data to this function in case of difference(s), which can prevent the need to re-run the equality function in order to log the difference(s).
+   */
+  equalityMetadata: unknown;
+}) => void;
 
 /**
  * A runtime 'feature flag' for changing the strangler mode.
@@ -48,7 +69,7 @@ export type OnComparison = (comparison: {
  *
  * We error check the value to make sure it is a valid `StranglerMode`.
  */
-export type FeatureFlag = () => Promise<string>
+export type FeatureFlag = () => Promise<string>;
 
 /**
  * The different possible modes available.
@@ -57,7 +78,7 @@ export type FeatureFlag = () => Promise<string>
  * - 'new-compare': Use the 'new' implementation, but run the 'old' in parallel and compare them.
  * - 'old-compare': Use the 'old' implementation, but run the 'new' in parallel and compare them.
  */
-export type StranglerMode = 'old' | 'new' | 'old-compare' | 'new-compare'
+export type StranglerMode = "old" | "new" | "old-compare" | "new-compare";
 
 /**
  * Configuration for Strangler.
@@ -70,20 +91,25 @@ export interface StranglerConfig {
    *
    * @default 300ms
    */
-  acceptableDurationDifference?: number
+  acceptableDurationDifference?: number;
   /**
    * Logger object with methods for different logging levels.
    *
    * @default console
    */
-  logger?: Partial<typeof console>
+  logger?: Partial<typeof console>;
   /**
    * The equality function to use to test if results are identical.
    *
    * @default `JSON.stringify(a) === JSON.stringify(b)`
-   * @returns `true` if the values are equal, false otherwise.
+   *    * @returns `{ isEqual: boolean; metadata: unknown }` where `isEqual` is true if the values are equal, false otherwise.
+   * `metadata` is additional metadata that can be used to identify the difference.
    */
-  equalityFn?: (a: unknown, b: unknown, parameters?: unknown) => boolean
+  equalityFn?: (
+    a: unknown,
+    b: unknown,
+    parameters?: unknown
+  ) => OnEqualityResult;
 
   /**
    * If true, will wait for the comparison to complete before returning the result.
@@ -91,15 +117,17 @@ export interface StranglerConfig {
    *
    * @default false
    */
-  waitForComparison?: boolean
+  waitForComparison?: boolean;
 }
 
 const defaultConfig: Required<StranglerConfig> = {
   acceptableDurationDifference: 300,
   logger: console,
-  equalityFn: (a, b) => JSON.stringify(a) === JSON.stringify(b),
+  equalityFn: (a, b) => ({
+    isEqual: JSON.stringify(a) === JSON.stringify(b),
+  }),
   waitForComparison: false,
-}
+};
 
 /**
  * A utility type for creating an interface from an existing class.
@@ -117,8 +145,8 @@ const defaultConfig: Required<StranglerConfig> = {
  * ```
  */
 export type I<T> = {
-  [K in keyof T]: T[K]
-}
+  [K in keyof T]: T[K];
+};
 
 /**
  * An error that is thrown while executing a Strangled operation.
@@ -132,9 +160,9 @@ export class ExecutionError extends Error {
     /// The error that was thrown causing this execution to fail.
     public readonly cause: unknown,
     /// The duration in milliseconds of the execution.
-    public readonly duration: number,
+    public readonly duration: number
   ) {
-    super(cause instanceof Error ? cause.message : String(cause))
+    super(cause instanceof Error ? cause.message : String(cause));
   }
 }
 
@@ -155,57 +183,71 @@ export function Strangler<T extends AsyncService, K extends keyof T>(
   newImplementation: { [P in K]: T[P] },
   oldImplementation: T,
   onComparison?: OnComparison,
-  config?: StranglerConfig,
+  config?: StranglerConfig
 ): T {
   const fullConfig = {
     ...defaultConfig,
     ...config,
-  }
+  };
 
   const isValidMode = (mode: string): mode is StranglerMode =>
-    ['old', 'new', 'old-compare', 'new-compare'].includes(mode)
+    ["old", "new", "old-compare", "new-compare"].includes(mode);
 
   return new Proxy(oldImplementation, {
     get(target, prop: string) {
-      const method = target[prop]
+      const method = target[prop];
 
-      if (typeof method === 'function') {
+      if (typeof method === "function") {
         return async (...args: unknown[]) => {
-          const mode = await featureFlag()
-          const hasNewImplementation = prop in newImplementation && typeof (newImplementation as any)[prop] === 'function'
-          const isCompareMode = mode === 'new-compare' || mode === 'old-compare'
+          const mode = await featureFlag();
+          const hasNewImplementation =
+            prop in newImplementation &&
+            typeof (newImplementation as Record<string, unknown>)[prop] ===
+              "function";
+          const isCompareMode =
+            mode === "new-compare" || mode === "old-compare";
 
           if (!isValidMode(mode)) {
-            fullConfig.logger.error?.(new Error(`Invalid StranglerMode: ${mode}`))
+            fullConfig.logger.error?.(
+              new Error(`Invalid StranglerMode: ${mode}`)
+            );
             // Fallback to 'old' implementation.
-            return (oldImplementation[prop] as AsyncFunction).apply(oldImplementation, args)
+            return (oldImplementation[prop] as AsyncFunction).apply(
+              oldImplementation,
+              args
+            );
           }
 
           // Compare mode.
           if (hasNewImplementation && isCompareMode) {
             const executeMethod = async (impl: AsyncService) => {
-              const start = performance.now()
+              const start = performance.now();
               try {
-                const result = await (impl[prop] as AsyncFunction).apply(impl, args)
+                const result = await (impl[prop] as AsyncFunction).apply(
+                  impl,
+                  args
+                );
                 return {
                   result,
                   duration: performance.now() - start,
-                }
+                };
               } catch (error) {
-                throw new ExecutionError(error, performance.now() - start)
+                throw new ExecutionError(error, performance.now() - start);
               }
-            }
+            };
 
             // Start both implementations running in parallel
-            const oldPromise = executeMethod(oldImplementation)
-            const newPromise = executeMethod(newImplementation)
+            const oldPromise = executeMethod(oldImplementation);
+            const newPromise = executeMethod(newImplementation);
 
             // Determine which promise to wait for based on the mode
             const [primaryPromise, secondaryPromise] =
-              mode === 'new-compare' ? [newPromise, oldPromise] : [oldPromise, newPromise]
+              mode === "new-compare"
+                ? [newPromise, oldPromise]
+                : [oldPromise, newPromise];
 
             // Wait only for the primary promise to complete
-            const primaryResult = await primaryPromise
+            const primaryResult = await primaryPromise;
 
             // After getting the primary result, wait for the secondary promise to complete in the background
             // and call onComparison when both are done
@@ -214,23 +256,35 @@ export function Strangler<T extends AsyncService, K extends keyof T>(
                 .catch((error) => error)
                 .then((secondaryResult) => {
                   const [oldResult, newResult] =
-                    mode === 'new-compare'
+                    mode === "new-compare"
                       ? [secondaryResult, primaryResult]
-                      : [primaryResult, secondaryResult]
+                      : [primaryResult, secondaryResult];
 
-                  const oldDuration = oldResult.duration
-                  const newDuration = newResult.duration
+                  const oldDuration = oldResult.duration;
+                  const newDuration = newResult.duration;
 
                   const oldValue =
-                    oldResult instanceof ExecutionError ? oldResult.cause : oldResult.result
+                    oldResult instanceof ExecutionError
+                      ? oldResult.cause
+                      : oldResult.result;
                   const newValue =
-                    newResult instanceof ExecutionError ? newResult.cause : newResult.result
+                    newResult instanceof ExecutionError
+                      ? newResult.cause
+                      : newResult.result;
 
                   try {
-                    const durationDifference = newDuration - oldDuration
-                    const areEqual = fullConfig.equalityFn(oldValue, newValue, args)
+                    const durationDifference = newDuration - oldDuration;
+                    const { isEqual, metadata } = fullConfig.equalityFn(
+                      oldValue,
+                      newValue,
+                      args
+                    );
 
-                    if (!areEqual || durationDifference > fullConfig.acceptableDurationDifference) {
+                    if (
+                      !isEqual ||
+                      durationDifference >
+                        fullConfig.acceptableDurationDifference
+                    ) {
                       onComparison({
                         oldResult: oldValue,
                         newResult: newValue,
@@ -238,36 +292,41 @@ export function Strangler<T extends AsyncService, K extends keyof T>(
                         newDuration: newDuration,
                         methodName: prop,
                         parameters: args,
-                      })
+                        equalityMetadata: metadata,
+                      });
                     }
                   } catch (error) {
                     fullConfig.logger.error?.(
-                      '[Strangler] Equality or comparison functions failed',
-                      { error },
-                    )
+                      "[Strangler] Equality or comparison functions failed",
+                      { error }
+                    );
                   }
-                })
+                });
 
               // If waitForComparison is true, wait for the secondary promise to complete before returning the result
               if (fullConfig.waitForComparison) {
-                await secondaryPromise.catch((error) => error)
+                await secondaryPromise.catch((error) => error);
               }
             }
 
             // Return the result from the primary implementation
-            return primaryResult.result
+            return primaryResult.result;
           }
 
           // Normal mode.
-          const useNew = mode === 'new' && hasNewImplementation
+          const useNew = mode === "new" && hasNewImplementation;
           const targetMethod = useNew
-            ? (newImplementation[prop as K] as AsyncFunction).bind(newImplementation)
-            : (oldImplementation[prop as K] as AsyncFunction).bind(oldImplementation)
-          return targetMethod(...args)
-        }
+            ? (newImplementation[prop as K] as AsyncFunction).bind(
+                newImplementation
+              )
+            : (oldImplementation[prop as K] as AsyncFunction).bind(
+                oldImplementation
+              );
+          return targetMethod(...args);
+        };
       }
 
-      return method
+      return method;
     },
-  })
+  });
 }


### PR DESCRIPTION
- [breaking change] Change expected returned type of equality function from `boolean` to `{ isEqual: boolean, metadata: unknown` }`
  - Allows to forward some metadata from equality function to comparison function